### PR TITLE
SensorNodeAttribute class & usage change

### DIFF
--- a/icostate/sensor.py
+++ b/icostate/sensor.py
@@ -24,17 +24,21 @@ class SensorNodeAttributes:
 
             The MAC address of the sensor node
 
+        adc_configuration:
+
+            The ADC configuration of the sensor node
+
     """
 
     def __init__(
         self,
-        name: str | None = None,
-        mac_address: EUI | None = None,
-        adc_configuration: ADCConfiguration | None = None,
+        name: str,
+        mac_address: EUI,
+        adc_configuration: ADCConfiguration,
     ) -> None:
-        self.name: str | None = name
-        self.mac_address: EUI | None = mac_address
-        self.adc_configuration: ADCConfiguration | None = adc_configuration
+        self.name: str = name
+        self.mac_address: EUI = mac_address
+        self.adc_configuration: ADCConfiguration = adc_configuration
 
     def __repr__(self) -> str:
         """Get the textual representation of the sensor node
@@ -55,35 +59,16 @@ class SensorNodeAttributes:
             ...                      mac_address=EUI("12-34-56-78-90-AB"),
             ...                      adc_configuration=config
             ...                     ) # doctest:+NORMALIZE_WHITESPACE
-            Name: hello,
-            MAC Address: 12-34-56-78-90-AB,
-            ADC Configuration: [Prescaler: 2,
-                                Acquisition Time: 8,
-                                Oversampling Rate: 64,
-                                Reference Voltage: 3.3 V]
-
-            Get representation of a sensor node with defined name
-
-            >>> SensorNodeAttributes(name="hello"
-            ...                     ) # doctest:+NORMALIZE_WHITESPACE
-            Name: hello,
-            MAC Address: Undefined,
-            ADC Configuration: Undefined
+            Name: hello, MAC Address: 12-34-56-78-90-AB, ADC Configuration: (Get, Prescaler: 2, Acquisition Time: 8, Oversampling Rate: 64, Reference Voltage: 3.3 V, True)
 
         """
 
-        def attribute_or_undefined(attribute, brackets: bool = False) -> str:
-            if attribute is None:
-                return "Undefined"
-
-            return f"[{attribute}]" if brackets else str(attribute)
-
         return ", ".join([
-            f"Name: {attribute_or_undefined(self.name)}",
-            f"MAC Address: {attribute_or_undefined(self.mac_address)}",
+            f"Name: {self.name}",
+            f"MAC Address: {self.mac_address}",
             (
                 "ADC Configuration: "
-                f"{attribute_or_undefined(self.adc_configuration, True)}"
+                f"{self.adc_configuration, True}"
             ),
         ])
 

--- a/icostate/sensor.py
+++ b/icostate/sensor.py
@@ -68,8 +68,8 @@ class SensorNodeAttributes:
             f"MAC Address: {self.mac_address}",
             f"ADC: "
             f"{self.adc_configuration.reference_voltage} | "
-            f"{self.adc_configuration.acquisition_time} | "        
-            f"{self.adc_configuration.prescaler} | "        
+            f"{self.adc_configuration.acquisition_time} | "
+            f"{self.adc_configuration.prescaler} | "
             f"{self.adc_configuration.oversampling_rate}"
         ])
 

--- a/icostate/sensor.py
+++ b/icostate/sensor.py
@@ -59,17 +59,18 @@ class SensorNodeAttributes:
             ...                      mac_address=EUI("12-34-56-78-90-AB"),
             ...                      adc_configuration=config
             ...                     ) # doctest:+NORMALIZE_WHITESPACE
-            Name: hello, MAC Address: 12-34-56-78-90-AB, ADC Configuration: (Get, Prescaler: 2, Acquisition Time: 8, Oversampling Rate: 64, Reference Voltage: 3.3 V, True)
+            Name: hello, MAC Address: 12-34-56-78-90-AB, ADC: 3.3 | 8 | 2 | 64
 
         """
 
         return ", ".join([
             f"Name: {self.name}",
             f"MAC Address: {self.mac_address}",
-            (
-                "ADC Configuration: "
-                f"{self.adc_configuration, True}"
-            ),
+            f"ADC: "
+            f"{self.adc_configuration.reference_voltage} | "
+            f"{self.adc_configuration.acquisition_time} | "        
+            f"{self.adc_configuration.prescaler} | "        
+            f"{self.adc_configuration.oversampling_rate}"
         ])
 
 

--- a/icostate/sensor.py
+++ b/icostate/sensor.py
@@ -59,18 +59,20 @@ class SensorNodeAttributes:
             ...                      mac_address=EUI("12-34-56-78-90-AB"),
             ...                      adc_configuration=config
             ...                     ) # doctest:+NORMALIZE_WHITESPACE
-            Name: hello, MAC Address: 12-34-56-78-90-AB, ADC: 3.3 | 8 | 2 | 64
+                Name: hello
+                MAC Address: 12-34-56-78-90-AB
+                ADC:
+                  Prescaler: 2
+                  Acquisition Time: 8
+                  Oversampling Rate: 64
+                  Reference Voltage: 3.3 V
 
         """
 
-        return ", ".join([
+        return "\n".join([
             f"Name: {self.name}",
             f"MAC Address: {self.mac_address}",
-            f"ADC: "
-            f"{self.adc_configuration.reference_voltage} | "
-            f"{self.adc_configuration.acquisition_time} | "
-            f"{self.adc_configuration.prescaler} | "
-            f"{self.adc_configuration.oversampling_rate}"
+            f"ADC:\n  {str(self.adc_configuration).replace(', ', '\n  ')}",
         ])
 
 

--- a/icostate/system.py
+++ b/icostate/system.py
@@ -335,7 +335,9 @@ class ICOsystem(AsyncIOEventEmitter):
         self.emit("sensor_node_adc_configuration", adc_configuration)
 
         self.sensor_node_attributes = SensorNodeAttributes(
-            mac_address=mac_address, name=name, adc_configuration=adc_configuration
+            mac_address=mac_address,
+            name=name,
+            adc_configuration=adc_configuration
         )
         self.state = State.SENSOR_NODE_CONNECTED
 

--- a/icostate/system.py
+++ b/icostate/system.py
@@ -331,9 +331,11 @@ class ICOsystem(AsyncIOEventEmitter):
         self.emit("sensor_node_mac_address", mac_address)
         name = await self.sensor_node.get_name()
         self.emit("sensor_node_name", name)
+        adc_configuration = await self.sensor_node.get_adc_configuration()
+        self.emit("sensor_node_adc_configuration", adc_configuration)
 
         self.sensor_node_attributes = SensorNodeAttributes(
-            mac_address=mac_address, name=name
+            mac_address=mac_address, name=name, adc_configuration=adc_configuration
         )
         self.state = State.SENSOR_NODE_CONNECTED
 


### PR DESCRIPTION
**This change hinges on the idea that a sensor node can never be without MAC address or ADC configuration. If that is misinformed, please advise.**

We now always require name, MAC and ADC configuration to create the SensorNodeAttributes object as there should not be an instance withouth this information. Additionally, we set this information upon connecting a sensor node.